### PR TITLE
Use more clear function names for Checkbox component

### DIFF
--- a/app/components/AdditionalReliefFormCard.js
+++ b/app/components/AdditionalReliefFormCard.js
@@ -33,7 +33,7 @@ export default class AdditionalReliefFormCard extends Component<Props> {
     onBack();
   };
 
-  handleChecked = (group: string) => {
+  handleToggleChecked = (group: string) => {
     const { onReliefOptionSelect, additionalReliefOptions } = this.props;
 
     const toggledValue = !additionalReliefOptions[group];
@@ -55,7 +55,7 @@ export default class AdditionalReliefFormCard extends Component<Props> {
             checked={additionalReliefOptions.subjectUnder21AtConviction}
             labelText="Select to dismiss convictions for people who were convicted of one of the above convictions at an age of 21 or younger."
             group="subjectUnder21AtConviction"
-            onCheck={this.handleChecked}
+            onChange={this.handleToggleChecked}
           >
             Dismiss convictions for people who were convicted of one of the
             above convictions at an age of 21 or younger.
@@ -64,7 +64,7 @@ export default class AdditionalReliefFormCard extends Component<Props> {
             checked={additionalReliefOptions.dismissOlderThanAgeThreshold}
             labelText="Select to dismiss convictions for people who are older than specified age."
             group="dismissOlderThanAgeThreshold"
-            onCheck={this.handleChecked}
+            onChange={this.handleToggleChecked}
           >
             Dismiss convictions for people who are older than X:
             <NumberSelect
@@ -82,7 +82,7 @@ export default class AdditionalReliefFormCard extends Component<Props> {
             }
             labelText="Dismiss convictions that occurred more than X years ago."
             group="dismissYearsSinceConvictionThreshold"
-            onCheck={this.handleChecked}
+            onChange={this.handleToggleChecked}
           >
             Dismiss convictions that occurred more than X years ago:
             <NumberSelect
@@ -100,7 +100,7 @@ export default class AdditionalReliefFormCard extends Component<Props> {
             checked={additionalReliefOptions.subjectHasOnlyProp64Charges}
             labelText="Select to dismiss convictions for people who only have HS 11357, 11358, 11359, 11360 convictions on their record."
             group="subjectHasOnlyProp64Charges"
-            onCheck={this.handleChecked}
+            onChange={this.handleToggleChecked}
           >
             Dismiss all HS 11357, HS 11358, HS 11359, or HS 11360 convictions if
             those are the only convictions on an individual's record.

--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -7,13 +7,13 @@ type Props = {
   group: string,
   labelText: string,
   value: string,
-  onCheck: (string, string) => void
+  onChange: (string, string) => void
 };
 
 export default class Checkbox extends Component<Props> {
-  handleCheck = () => {
-    const { onCheck, group, value } = this.props;
-    onCheck(group, value);
+  handleChange = () => {
+    const { onChange, group, value } = this.props;
+    onChange(group, value);
   };
 
   render() {
@@ -35,7 +35,7 @@ export default class Checkbox extends Component<Props> {
             name={group}
             value={true}
             id={`true_${group}`}
-            onChange={this.handleCheck}
+            onChange={this.handleChange}
           />
         </label>
       </div>

--- a/test/components/Checkbox.spec.js
+++ b/test/components/Checkbox.spec.js
@@ -9,20 +9,20 @@ Enzyme.configure({ adapter: new Adapter() });
 const sandbox = sinon.createSandbox();
 
 function setup(checked) {
-  const onCheckSpy = sandbox.spy();
+  const onChangeSpy = sandbox.spy();
   const component = shallow(
     <Checkbox
       labelText="Caterine Vauban"
       checked={checked}
       group="nihilists"
-      onCheck={onCheckSpy}
+      onChange={onChangeSpy}
     >
       This is a checkbox
     </Checkbox>
   );
   return {
     component,
-    onCheckSpy
+    onChangeSpy
   };
 }
 
@@ -63,12 +63,12 @@ describe('Checkbox component', () => {
     expect(component.find('input').props().id).toEqual('true_nihilists');
   });
 
-  it('calls onCheck with the group and value when checkbox is clicked', () => {
-    const { component, onCheckSpy } = setup();
+  it('calls onChange with the group and value when checkbox is clicked', () => {
+    const { component, onChangeSpy } = setup();
     component.find('input').simulate('change');
 
-    expect(onCheckSpy.called).toEqual(true);
-    const { args } = onCheckSpy.getCall(0);
+    expect(onChangeSpy.called).toEqual(true);
+    const { args } = onChangeSpy.getCall(0);
     expect(args[0]).toEqual('nihilists');
   });
 


### PR DESCRIPTION
Minor naming cleanup for clarity - checkboxes can be changed from unchecked to checked, or from checked to unchecked, so I wanted to use names that made it clear we weren't always handling a checked state.