### PR TITLE
Provide mock scrollTo for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
       "^.+\\.jsx?$": "babel-jest"
     },
     "setupFiles": [
-      "./internals/scripts/CheckBuiltsExist.js"
+      "./internals/scripts/CheckBuiltsExist.js",
+      "./test/setup.js"
     ]
   },
   "devDependencies": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,1 @@
+window.scrollTo = () => {};


### PR DESCRIPTION
Browser used in Jest doesn't have scrollTo support (though our live app
does), so was producing noisy test failures. To prevent this, we now mock
out window.scrollTo in tests.