### PR TITLE
Make time-to-complete more human in summary PDF

### DIFF
--- a/app/components/SummaryReportPdf.js
+++ b/app/components/SummaryReportPdf.js
@@ -9,7 +9,8 @@ import {
   formatDateTime,
   toTitleCase,
   convertTimestamp,
-  formatLineCountWithCommas
+  formatLineCountWithCommas,
+  formattedProcessingTime
 } from '../utils/formatSummaryOutputUtils';
 import cmrLogo from '../assets/images/cmr_black_logo.png';
 import bullet from '../assets/images/bullet.png';
@@ -92,9 +93,9 @@ export default class SummaryReportPdf extends Component<Props> {
               </Text>
               <Text style={styles.text}>
                 This application processed {formattedLineCount} lines of data in{' '}
-                {summaryData.processingTimeInSeconds.toFixed(3)} seconds and
-                produced {inputFileCount * 3} spreadsheets to assist with your
-                office’s review.
+                {formattedProcessingTime(summaryData.processingTimeInSeconds)}{' '}
+                and produced {inputFileCount * 3} spreadsheets to assist with
+                your office’s review.
               </Text>
             </View>
             <View>

--- a/app/utils/formatSummaryOutputUtils.js
+++ b/app/utils/formatSummaryOutputUtils.js
@@ -62,3 +62,10 @@ export function convertTimestamp(timestamp) {
 export function formatLineCountWithCommas(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
+
+export function formattedProcessingTime(timeInSeconds) {
+  if (timeInSeconds >= 90) {
+    return `${Math.round(timeInSeconds / 6) / 10} minutes`;
+  }
+  return `${Math.round(timeInSeconds * 10) / 10} seconds`;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clearmyrecord-hs_11361",
   "productName": "Clear My Record",
-  "version": "1.0.1-rc1",
+  "version": "1.0.1-rc2",
   "description": "Electron app to configure eligibility logic and identify convictions eligible for CA Prop 64 relief",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",

--- a/test/utils/formatSummaryOutputUtils.spec.js
+++ b/test/utils/formatSummaryOutputUtils.spec.js
@@ -25,7 +25,7 @@ describe('formattedProcessingTime', () => {
   });
 
   describe('time is under 90 seconds', () => {
-    it('should return time in minutes, rounded to tenth', () => {
+    it('should return time in seconds, rounded to tenth', () => {
       expect(formattedProcessingTime(11.33458)).toEqual('11.3 seconds');
     });
   });

--- a/test/utils/formatSummaryOutputUtils.spec.js
+++ b/test/utils/formatSummaryOutputUtils.spec.js
@@ -1,4 +1,7 @@
-import { formatLineCountWithCommas } from '../../app/utils/formatSummaryOutputUtils';
+import {
+  formatLineCountWithCommas,
+  formattedProcessingTime
+} from '../../app/utils/formatSummaryOutputUtils';
 
 describe('formatLineCountWithCommas', () => {
   describe('when the input number is greater than 1000', () => {
@@ -10,6 +13,20 @@ describe('formatLineCountWithCommas', () => {
   describe('when the input number is less than 1000', () => {
     it('returns the input number without commas added', () => {
       expect(formatLineCountWithCommas(999)).toEqual('999');
+    });
+  });
+});
+
+describe('formattedProcessingTime', () => {
+  describe('time is 90 seconds or over', () => {
+    it('should return time in minutes, rounded to tenth', () => {
+      expect(formattedProcessingTime(91.33458)).toEqual('1.5 minutes');
+    });
+  });
+
+  describe('time is under 90 seconds', () => {
+    it('should return time in minutes, rounded to tenth', () => {
+      expect(formattedProcessingTime(11.33458)).toEqual('11.3 seconds');
     });
   });
 });


### PR DESCRIPTION
Shortens all times to the tenth of a measurement, and uses minutes for
measuring time-to-complete greater than or equal to 90 seconds.

[Finishes #168223705]